### PR TITLE
fixbug, bot break reply  when reply has URI

### DIFF
--- a/src/webapp/slack.go
+++ b/src/webapp/slack.go
@@ -98,7 +98,7 @@ func HubotSlackWebhook(c web.C, _ http.ResponseWriter, r *http.Request) {
 
 	// 顔文字をランダムで付与する
 	idx := random.Int31n((int32)(len(Kaomoji) - 1))
-	message := resMessage + Kaomoji[idx]
+	message := resMessage + " " + Kaomoji[idx]
 	// 結果を非同期でSlackへ
 	go Send(bot.Name, m.channelID, message)
 }


### PR DESCRIPTION
added only one space :)
![2014-12-22 11 22 39](https://cloud.githubusercontent.com/assets/909198/5520663/e17f6aac-89cc-11e4-8c17-2c2e67d6a1e6.png)
